### PR TITLE
Add CI/CD for semi-automated PyPI releases

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -1,0 +1,39 @@
+name: Build and publish
+
+on:
+  push:
+    branches:
+      - "main"
+    tags:
+      - '*.*.*'
+
+jobs:
+  ci_cd:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.10
+
+      - name: Install pypa/build
+        run: python -m pip install build --user
+
+      - name: Build a binary wheel and a source tarball
+        run: python -m build --sdist --wheel --outdir dist/ .
+
+      - name: Publish package to TestPyPI (for main branch)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: ${{ secrets.TEST_PYPI_USERNAME }}
+          password: ${{ secrets.TEST_PYPI_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+          skip_existing: true
+
+      - name: Publish CLI package to PyPI (for tags)
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: ${{ secrets.PYPI_USERNAME }}
+          password: ${{ secrets.PYPI_TOKEN }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,10 +28,10 @@ classifiers =
     Operating System :: POSIX
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Software Development
     Topic :: Software Development :: Bug Tracking
     Topic :: Software Development :: Quality Assurance


### PR DESCRIPTION
This PR adds semi-automated releases for `steampunk-scanner` CLI (see #4):

- Publish development package to [Test PyPI](https://test.pypi.org/project/steampunk-scanner/) instance with every new push on main branch
- Publish production package to [PyPI](https://pypi.org/project/steampunk-scanner/) instance every time we manually push a new tag

Closes #4.