### PR TITLE
No early out on error

### DIFF
--- a/src/steampunk_scanner/commands/scan.py
+++ b/src/steampunk_scanner/commands/scan.py
@@ -58,6 +58,7 @@ def _parser_callback(args: argparse.Namespace):
 
 
 def _print_scan_output(out_fh, input_tasks, output_tasks):
+    failed = False
     """
     Prints scan output
     :param out_fh: File handle to print result to
@@ -80,9 +81,10 @@ def _print_scan_output(out_fh, input_tasks, output_tasks):
 
         for error in errors:
             print(f"{file_name}:{task_line}: ERROR: {error}", file=out_fh)
+            failed = True
 
         for hint in hints:
             print(f"{file_name}:{task_line}: HINT: {hint}", file=out_fh)
 
-    if errors:
+    if failed:
         sys.exit(1)


### PR DESCRIPTION
There was a bug, which terminated output on first task with error. We
must iterate through all of them and only after that return error status.

Side effect with bug was, that in case of any failed task, we skip output
for all tasks behind that one.